### PR TITLE
Improve contributor list display on small screens

### DIFF
--- a/src/lib/components/contribution-summary.svelte
+++ b/src/lib/components/contribution-summary.svelte
@@ -20,7 +20,7 @@
 	<div>
 		<div>{contrib.title}</div>
 		<div>
-			<div class="text-sm flex space-x-1">
+			<div class="text-sm flex flex-wrap space-x-1">
 				<span>{prettyPrintDate(contrib.date)}</span> <span>&middot;</span>
 				{#each contrib.contributors as contributor, index}
 					<a href="/{contributor.local_handle}" class="l"


### PR DESCRIPTION
# Issue:

The contributor list wasn't wrapping on small screens. As a result, the list items were not fully visible on smaller devices.

Closes #1

# Solution:

I added the flex-wrap Tailwind class to the contribution-summary component to ensure that the contributor list wraps and becomes multi-line on smaller screens.

# Testing:

Tested on various screen sizes to ensure the contributor list wraps correctly without breaking other layout elements.

<img width="417" alt="Screen Shot 2024-08-17 at 19 30 25" src="https://github.com/user-attachments/assets/978c6d88-2208-4374-b0f9-1b9f8350b16a">
