### PR TITLE
Fix date input issue #6

### DIFF
--- a/src/lib/components/DateInput.svelte
+++ b/src/lib/components/DateInput.svelte
@@ -7,7 +7,7 @@
 	let internal;
 
 	const input = (x) => (internal = dayjs(x).format(format));
-	const output = (x) => (date = dayjs(x, format).toDate());
+	const output = (x) => (date = new Date(internal));
 
 	$: input(date);
 	$: output(internal);


### PR DESCRIPTION
The bug occurred because of a problem with date formatting and conversion within the DateInput.svelte component.

**Changes:**
Adjusted the logic in DateInput.svelte to ensure proper date handling and conversion.

Replaced the existing code that incorrectly handled date formatting and conversion with a simplified approach that directly binds the input date to the correct format.

Fixes: Issue #6